### PR TITLE
Remove StructSym and BuiltinTypeSym from inheriting Type. Instead, they shall compose it

### DIFF
--- a/TestBluefin/symbolTable/InheritanceTests.cpp
+++ b/TestBluefin/symbolTable/InheritanceTests.cpp
@@ -35,7 +35,7 @@ namespace SymbolTableTests {
 		Declaration declarationListener(symTab, symFact);
 		walker.walk(&declarationListener, tree);
 
-		Resolution resolutionListener(declarationListener.getScopes(), output);
+		Resolution resolutionListener(declarationListener.getScopes(), output, symTab);
 		walker.walk(&resolutionListener, tree);
 
 		string expectedOutput = readFile(pathPrefix + expectedOutputFile);

--- a/TestBluefin/symbolTable/PolymorphismTests.cpp
+++ b/TestBluefin/symbolTable/PolymorphismTests.cpp
@@ -36,7 +36,7 @@ namespace SymbolTableTests {
 		Declaration declarationListener(symTab, symFact);
 		walker.walk(&declarationListener, tree);
 
-		Resolution resolutionListener(declarationListener.getScopes(), output);
+		Resolution resolutionListener(declarationListener.getScopes(), output, symTab);
 		walker.walk(&resolutionListener, tree);
 
 		string expectedOutput = readFile(pathPrefix + expectedOutputFile);

--- a/TestBluefin/symbolTable/PopulateSymTabTests.cpp
+++ b/TestBluefin/symbolTable/PopulateSymTabTests.cpp
@@ -35,7 +35,7 @@ namespace SymbolTableTests {
 		Declaration declarationListener(symTab, symFact);
 		walker.walk(&declarationListener, tree);
 
-		Resolution resolutionListener(declarationListener.getScopes(), output);
+		Resolution resolutionListener(declarationListener.getScopes(), output, symTab);
 		walker.walk(&resolutionListener, tree);
 
 		string expectedOutput = readFile(pathPrefix + expectedOutputFile);

--- a/TestBluefin/symbolTable/PostOrderPrintType.cpp
+++ b/TestBluefin/symbolTable/PostOrderPrintType.cpp
@@ -14,8 +14,8 @@ varName - t_type - t_promotedType
 */
 void PostOrderPrintType::exitEveryRule(antlr4::ParserRuleContext* ctx)  {
 	if (exprTypeContexts.find(ctx) != exprTypeContexts.end()) {
-		string typeStr = exprTypeContexts.at(ctx).getEvalType()->type2str();
-		string promoteTypeStr = exprTypeContexts.at(ctx).getPromotionType()->type2str();
+		string typeStr = exprTypeContexts.at(ctx).getEvalType().type2str();
+		string promoteTypeStr = exprTypeContexts.at(ctx).getPromotionType().type2str();
 		output += ctx->getText() + " - t_" + typeStr + " - t_" + promoteTypeStr + "\n";
 	}
 }

--- a/TestBluefin/symbolTable/StructSymbolTestWrapper.cpp
+++ b/TestBluefin/symbolTable/StructSymbolTestWrapper.cpp
@@ -22,10 +22,10 @@ shared_ptr<Symbol> StructSymbolTestWrapper::resolveMember(const string memberNam
 
 string StructSymbolTestWrapper::createResolveMemberDebugMsg(shared_ptr<Symbol> resolvedSym) const
 {
-	const string structTypeName = type2str();
+	const string structTypeName = getType().type2str();
 	const string resolvedSymName = resolvedSym->getName();
 	const string symCategory = getSymbolCategory(resolvedSym);;
-	const string symType = resolvedSym->getType()->type2str();
+	const string symType = resolvedSym->getType().type2str();
 
 	return "resolve - " + structTypeName + "::" + resolvedSymName + " - c_" + symCategory + " - t_" + symType + "\n";
 
@@ -33,7 +33,7 @@ string StructSymbolTestWrapper::createResolveMemberDebugMsg(shared_ptr<Symbol> r
 
 string StructSymbolTestWrapper::createUnresolvedMemberDebugMsg(string unresolvedMemberName) const {
 
-	const string structTypeName = type2str();
+	const string structTypeName = getType().type2str();
 
 	return "resolve - " + structTypeName + "::" + unresolvedMemberName + " - " "UNRESOLVED\n";
 }

--- a/TestBluefin/symbolTable/SymbolTableTestWrapper.cpp
+++ b/TestBluefin/symbolTable/SymbolTableTestWrapper.cpp
@@ -55,6 +55,19 @@ shared_ptr<Symbol> SymbolTableTestWrapper::resolve(const string name) {
 	return resolvedSym;
 }
 
+shared_ptr<Symbol> SymbolTableTests::SymbolTableTestWrapper::getSymbolMatchingType(Type type)
+{
+	shared_ptr<Symbol> sym;
+	try {
+		sym = SymbolTable::getSymbolMatchingType(type);
+	}
+	catch (UnresolvedSymbolException e) {
+		output += createUnresolvedDebugMsg(type.type2str());
+	}
+
+	return sym;
+}
+
 string SymbolTableTestWrapper::createEnterScopeDebugMsg() {
 
 	scopeLevel++;
@@ -82,7 +95,7 @@ string SymbolTableTestWrapper::createExitScopeDebugMsg() {
 string SymbolTableTestWrapper::createDeclareDebugMsg(shared_ptr<Symbol> symbol) const {
 	const string symName = symbol->getName();
 	const string symCategory = getSymbolCategory(symbol);
-	const string symType = symbol->getType()->type2str();
+	const string symType = symbol->getType().type2str();
 
 	return "declare - " + symName + " - c_" + symCategory + " - t_" + symType + "\n";
 }
@@ -96,7 +109,7 @@ string SymbolTableTestWrapper::createRedeclarationDebugMsg(shared_ptr<Symbol> sy
 string SymbolTableTestWrapper::createResolveDebugMsg(shared_ptr<Symbol> resolvedSym) const {
 	const string resolvedSymName = resolvedSym->getName();
 	const string symCategory = getSymbolCategory(resolvedSym);
-	const string symType = resolvedSym->getType()->type2str();
+	const string symType = resolvedSym->getType().type2str();
 
 	return "resolve - " + resolvedSymName + " - c_" + symCategory + " - t_" + symType + "\n";
 }

--- a/TestBluefin/symbolTable/SymbolTableTestWrapper.h
+++ b/TestBluefin/symbolTable/SymbolTableTestWrapper.h
@@ -48,6 +48,8 @@ namespace SymbolTableTests {
 
 		shared_ptr<Symbol> resolve(const string name) override;
 
+		shared_ptr<Symbol> getSymbolMatchingType(Type type) override;
+
 	private:
 		string& output;
 		unsigned scopeLevel;

--- a/TestBluefin/symbolTable/TypeTests.cpp
+++ b/TestBluefin/symbolTable/TypeTests.cpp
@@ -42,11 +42,11 @@ namespace SymbolTableTests {
 		Declaration declarationListener(symTab, symFact);
 		walker.walk(&declarationListener, tree);
 
-		Resolution resolutionListener(declarationListener.getScopes(), dummy);
+		Resolution resolutionListener(declarationListener.getScopes(), dummy, symTab);
 		walker.walk(&resolutionListener, tree);
 
 		map<ParseTree*, shared_ptr<Scope>> scopes = declarationListener.getScopes(); 
-		DecorateExprWithTypes decorateExprListener(scopes, symFact);
+		DecorateExprWithTypes decorateExprListener(scopes, symFact, symTab);
 		walker.walk(&decorateExprListener, tree);
 
 		string symbolTypesStr;

--- a/TestBluefin/symbolTable/scopeTests.cpp
+++ b/TestBluefin/symbolTable/scopeTests.cpp
@@ -122,8 +122,8 @@ namespace SymbolTableTests {
 		SymbolTable symtab;
 		symtab.enterScope("First");
 
-		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
-		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::FLOAT)), 0);
+		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", Type::INT(), 0);
+		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", Type::FLOAT(), 0);
 		symtab.declare(symA);
 		symtab.declare(symB); 
 
@@ -138,14 +138,14 @@ namespace SymbolTableTests {
 		SymbolTable symtab;
 
 		symtab.enterScope("First");
-		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
-		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::FLOAT)), 0);
+		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", Type::INT(), 0);
+		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", Type::FLOAT(), 0);
 		symtab.declare(symA);
 		symtab.declare(symB); 
 
 		symtab.enterScope("Second");
-		shared_ptr<Symbol> symC = make_shared<VariableSymbol>("c", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
-		shared_ptr<Symbol> symD = make_shared<VariableSymbol>("d", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::FLOAT)), 0);
+		shared_ptr<Symbol> symC = make_shared<VariableSymbol>("c", Type::INT(), 0);
+		shared_ptr<Symbol> symD = make_shared<VariableSymbol>("d", Type::FLOAT(), 0);
 		symtab.declare(symC);
 		symtab.declare(symD); 
 
@@ -169,15 +169,15 @@ namespace SymbolTableTests {
 		SymbolTable symtab;
 
 		symtab.enterScope("First");
-		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
-		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::FLOAT)), 0);
+		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", Type::INT(), 0);
+		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", Type::FLOAT(), 0);
 		symtab.declare(symA);
 		symtab.declare(symB);
 
 		symtab.enterScope("Second");
-		shared_ptr<Symbol> symA2 = make_shared<VariableSymbol>("a", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
-		shared_ptr<Symbol> symB2 = make_shared<VariableSymbol>("b", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::FLOAT)), 0);
-		shared_ptr<Symbol> symD = make_shared<VariableSymbol>("d", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
+		shared_ptr<Symbol> symA2 = make_shared<VariableSymbol>("a", Type::INT(), 0);
+		shared_ptr<Symbol> symB2 = make_shared<VariableSymbol>("b", Type::FLOAT(), 0);
+		shared_ptr<Symbol> symD = make_shared<VariableSymbol>("d", Type::INT(), 0);
 		symtab.declare(symA2);
 		symtab.declare(symB2);
 		symtab.declare(symD);
@@ -211,8 +211,8 @@ namespace SymbolTableTests {
 		SymbolTable symtab;
 
 		symtab.enterScope("First");
-		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
-		shared_ptr<Symbol> symAFunc = make_shared<FunctionSymbol>("a", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::FLOAT)), 0);
+		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", Type::INT(), 0);
+		shared_ptr<Symbol> symAFunc = make_shared<FunctionSymbol>("a", Type::FLOAT(), 0);
 		symtab.declare(symA);
 
 		ASSERT_THROW(symtab.declare(symAFunc), ReclarationException);
@@ -223,8 +223,8 @@ namespace SymbolTableTests {
 		SymbolTable symtab;
 
 		symtab.enterScope("First");
-		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
-		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::FLOAT)), 0);
+		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", Type::INT(), 0);
+		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", Type::FLOAT(), 0);
 		symtab.declare(symA);
 		symtab.declare(symB);
 
@@ -242,13 +242,13 @@ namespace SymbolTableTests {
 		SymbolTable symtab;
 
 		symtab.enterScope("First");
-		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
-		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::FLOAT)), 0);
+		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", Type::INT(), 0);
+		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", Type::STRING(), 0);
 		symtab.declare(symA);
 		symtab.declare(symB);
 
 		symtab.enterScope("Second");
-		shared_ptr<Symbol> symA2 = make_shared<VariableSymbol>("a", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
+		shared_ptr<Symbol> symA2 = make_shared<VariableSymbol>("a", Type::INT(), 0);
 		symtab.declare(symA2);
 
 		shared_ptr<Symbol> resA2 = symtab.resolve("a");
@@ -266,8 +266,8 @@ namespace SymbolTableTests {
 		SymbolTable symtab;
 
 		symtab.enterScope("First");
-		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
-		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
+		shared_ptr<Symbol> symA = make_shared<VariableSymbol>("a", Type::INT(), 0);
+		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", Type::INT(), 0);
 		symtab.declare(symA);
 		symtab.declare(symB);
 
@@ -282,14 +282,14 @@ namespace SymbolTableTests {
 		SymbolTable symtab;
 
 		symtab.enterScope("First");
-		shared_ptr<Symbol> globalB = make_shared<VariableSymbol>("b", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
+		shared_ptr<Symbol> globalB = make_shared<VariableSymbol>("b", Type::INT(), 0);
 		symtab.declare(globalB);
 		shared_ptr<Symbol> structA = make_shared<StructSymbol>("A", symtab.getCurrScope()); 
 		symtab.declare(structA);
 
 		symtab.setCurrentScope(dynamic_pointer_cast<Scope>(structA));
-		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
-		shared_ptr<Symbol> symC = make_shared<VariableSymbol>("c", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::STRING)), 0);
+		shared_ptr<Symbol> symB = make_shared<VariableSymbol>("b", Type::INT(), 0);
+		shared_ptr<Symbol> symC = make_shared<VariableSymbol>("c", Type::STRING(), 0);
 		symtab.declare(symB);
 		symtab.declare(symC);
 		symtab.exitScope();
@@ -310,13 +310,13 @@ namespace SymbolTableTests {
 		SymbolTable symtab;
 
 		symtab.enterScope("First");
-		shared_ptr<Symbol> globalB = make_shared<VariableSymbol>("b", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::INT)), 0);
+		shared_ptr<Symbol> globalB = make_shared<VariableSymbol>("b", Type::INT(), 0);
 		symtab.declare(globalB);
 		shared_ptr<Symbol> structA = make_shared<StructSymbol>("A", symtab.getCurrScope());
 		symtab.declare(structA);
 
 		symtab.setCurrentScope(dynamic_pointer_cast<Scope>(structA));
-		shared_ptr<Symbol> symC = make_shared<VariableSymbol>("c", dynamic_pointer_cast<Type>(symFact->createBuiltinTypeSymbol(SFB::STRING)), 0);
+		shared_ptr<Symbol> symC = make_shared<VariableSymbol>("c", Type::INT(), 0);
 		symtab.declare(symC);
 		symtab.exitScope();
 

--- a/listeners/DecorateExprWithTypes.h
+++ b/listeners/DecorateExprWithTypes.h
@@ -33,8 +33,8 @@ namespace bluefin {
 	public:
 
 		// For testing, we'll pass in an adapter of a symbol table
-		DecorateExprWithTypes(map<ParseTree*, shared_ptr<Scope>> scopeOfPrimaryIds, SymbolFactory& factory) :
-			scopeOfPrimaryIdsVarDeclAndFuncDefs{ scopeOfPrimaryIds }, symbolFactory{ factory }, currFuncDefCtx{ nullptr }
+		DecorateExprWithTypes(map<ParseTree*, shared_ptr<Scope>> scopeOfPrimaryIds, SymbolFactory& factory, SymbolTable& symTab) :
+			scopeOfPrimaryIdsVarDeclAndFuncDefs{ scopeOfPrimaryIds }, symbolFactory{ factory }, symbolTable{ symTab }, currFuncDefCtx{ nullptr }
 		{}
 
 		//===== listener methods for obtaining/evaluating expression types
@@ -69,6 +69,7 @@ namespace bluefin {
 
 	private:
 		SymbolFactory& symbolFactory;
+		SymbolTable& symbolTable;
 		map<ParseTree*, shared_ptr<Scope>> scopeOfPrimaryIdsVarDeclAndFuncDefs;
 
 		map<ParseTree*, TypeContext> typeContexts; // stores the type associated with expressions and functions. Enables type checking
@@ -82,28 +83,46 @@ namespace bluefin {
 		//      a) For arithmetic expr, compute its own type from its children's type. Then check whether this expression has compatible types
 		//			THen compute its children's promoteTo type
 		//		b) For equality and relational, compute children's promotTo type and set own type to bool. Same wtih promoteTo type (since that won't change)
-		shared_ptr<Type> getArithmeticExprType(shared_ptr<Type> left, shared_ptr<Type> right);
-		shared_ptr<Type> getPromotionType(shared_ptr<Type> left, shared_ptr<Type> right);
+		Type getArithmeticExprType(Type left, Type right);
+		Type getPromotionType(Type left, Type right);
 
-		bool areBothBoolType(shared_ptr<Type> left, shared_ptr<Type> right) const;
-		bool areArithmeticallyCompatible(shared_ptr<Type> left, shared_ptr<Type> right) const;
-		bool isAssignmentCompatible(shared_ptr<Type> left, shared_ptr<Type> right) const;
+		bool areBothBoolType(Type left, Type right) const;
+		bool areArithmeticallyCompatible(Type left, Type right) const;
+		bool isAssignmentCompatible(Type left, Type right) const;
 
 
 		// can't use pair with unordered_map here b/c pair doesn't have a hash key
+		/*
 		const map<pair<shared_ptr<Type>, shared_ptr<Type>>, shared_ptr<Type>> arithmeticExprType{
 			{{BTS::INT(), BTS::INT()}, BTS::INT()},
 			{{BTS::INT(), BTS::FLOAT()}, BTS::FLOAT()},
 			{{BTS::FLOAT(), BTS::INT()}, BTS::FLOAT()},
 			{{BTS::FLOAT(), BTS::FLOAT()}, BTS::FLOAT()}
 		};
+		*/
+		const map<pair<Type, Type>, Type> arithmeticExprType{
+			{{ Type::INT(), Type::INT()}, Type::INT()},
+			{{ Type::INT(), Type::FLOAT()}, Type::FLOAT()},
+			{{ Type::FLOAT(), Type::INT()}, Type::FLOAT()},
+			{{ Type::FLOAT(), Type::FLOAT()}, Type::FLOAT()}
+		};
 
+		/*
 		const map<pair<shared_ptr<Type>, shared_ptr<Type>>, shared_ptr<Type>> promotionFromTo{
 			{{BTS::BOOL(), BTS::BOOL()}, BTS::BOOL()},
 			{{BTS::INT(), BTS::FLOAT()}, BTS::FLOAT()},
 			{{BTS::INT(), BTS::INT()}, BTS::INT()},
 			{{BTS::FLOAT(), BTS::INT()}, BTS::FLOAT()},
 			{{BTS::FLOAT(), BTS::FLOAT()}, BTS::FLOAT()}
+		};
+		*/
+
+		const map<pair<Type, Type>, Type> promotionFromTo{
+			{{Type::BOOL(), Type::BOOL()}, Type::BOOL()},
+			{{Type::INT(), Type::FLOAT()}, Type::FLOAT()},
+			{{Type::INT(), Type::INT()}, Type::INT()},
+			{{Type::FLOAT(), Type::INT()}, Type::FLOAT()},
+			{{Type::FLOAT(), Type::FLOAT()}, Type::FLOAT()}
 		};
 	};
 }

--- a/listeners/Resolution.h
+++ b/listeners/Resolution.h
@@ -29,8 +29,8 @@ namespace bluefin {
 	public:
 		// For testing, we'll pass in an adapter of a symbol table
 		// TODO: find some way to decouple testing of output from Resolution
-		Resolution(map<ParseTree*, shared_ptr<Scope>> scopes, string& output) : 
-			scopes{ scopes }, output{ output }
+		Resolution(map<ParseTree*, shared_ptr<Scope>> scopes, string& output, SymbolTable& symTab) : 
+			scopes{ scopes }, output{ output }, symbolTable{symTab}
 		{}
 
 		void enterPrimaryId(bluefinParser::PrimaryIdContext*) override;
@@ -44,6 +44,7 @@ namespace bluefin {
 		map<ParseTree*, shared_ptr<Scope>> scopes;
 		pair<shared_ptr<Symbol>, shared_ptr<Scope>> resolve(const string name, shared_ptr<Scope> startScope);
 
+		SymbolTable& symbolTable;
 		/* 
 		The purpose of this stack is to enable resolution of struct members. Since each 
 		listener's return type is void, there's no implicit way for the child of a node 

--- a/symbolTable/BuiltinTypeSymbol.h
+++ b/symbolTable/BuiltinTypeSymbol.h
@@ -8,7 +8,7 @@ namespace bluefin {
 
 	using std::shared_ptr;
 
-	class BuiltinTypeSymbol : public Type, public Symbol
+	class BuiltinTypeSymbol : public Symbol
 	{
 	public:
 		static shared_ptr<BuiltinTypeSymbol> INT() {
@@ -35,9 +35,12 @@ namespace bluefin {
 		}
 
 
-		inline string type2str() const override { return getName(); }
-
 	private:
-		BuiltinTypeSymbol(string type) : Symbol{ type, this } {}
+		BuiltinTypeSymbol(string type) : Symbol{ type, Type{type}, 0 } {}
 	};
+	/*
+	Symbol(const string& name, Type type, size_t tokenIndex) : 
+		name{ name }, type{ type }, tokenIndex{ tokenIndex }
+	{}
+	*/
 }

--- a/symbolTable/FunctionSymbol.h
+++ b/symbolTable/FunctionSymbol.h
@@ -10,7 +10,6 @@ namespace bluefin {
 
 	using std::string;
 	using std::shared_ptr;
-	using std::move;
 	using std::vector;
 
 	/* TODO: should this contain its own arguments?
@@ -23,8 +22,8 @@ namespace bluefin {
 	class FunctionSymbol : public Symbol {
 	public:
 
-		FunctionSymbol(const string& name, shared_ptr<Type> type, size_t tokenIndex) :
-			Symbol(name, move(type), tokenIndex)
+		FunctionSymbol(const string& name, Type type, size_t tokenIndex) :
+			Symbol(name, type, tokenIndex)
 		{}
 
 		void attachParam(shared_ptr<Symbol>); 

--- a/symbolTable/StructSymbol.h
+++ b/symbolTable/StructSymbol.h
@@ -13,12 +13,12 @@ namespace bluefin {
 	/** 
 	Might be circular reference to have a sp to enclosing scope. Consider using wp
 	*/
-	class StructSymbol : public Symbol, public Type, public Scope
+	class StructSymbol : public Symbol, public Scope
 	{
 
 	public:
 		StructSymbol(const string& name, shared_ptr<Scope> enclosingScope, shared_ptr<StructSymbol> superClass=nullptr) : 
-			Symbol(name, this), Scope{ enclosingScope, name }, superClass{ superClass }
+			Symbol(name, Type{ name }), Scope{ enclosingScope, name }, superClass{ superClass }
 		{}
 
 		/*
@@ -37,7 +37,6 @@ namespace bluefin {
 
 		shared_ptr<Scope> getParentScope() const override;
 
-		inline string type2str() const override { return Symbol::getName(); }
 		inline shared_ptr<StructSymbol> getSuperClass() const { return superClass; }
 
 	private:

--- a/symbolTable/Symbol.cpp
+++ b/symbolTable/Symbol.cpp
@@ -6,8 +6,8 @@ using namespace bluefin;
 using std::shared_ptr;
 bool Symbol::operator==(Symbol& rhs)
 {
-	shared_ptr<Type> thisType = this->getType();
-	shared_ptr<Type> rhsType = rhs.getType();
+	Type thisType = this->getType();
+	Type rhsType = rhs.getType();
 	return this->name == rhs.name
 		&& this->type == rhs.type;
 }

--- a/symbolTable/Symbol.h
+++ b/symbolTable/Symbol.h
@@ -18,13 +18,13 @@ namespace bluefin {
 		bool operator==(Symbol& rhs);
 
 		inline string getName() const { return name; }
-		inline shared_ptr<Type> getType() const  { return type; }
+		inline Type getType() const  { return type; }
 		inline size_t getTokenIndex() const { return tokenIndex; }
 		virtual ~Symbol() {}
 
 	protected:
 		// name is the name of the id, eg, a, hello, wow
-		Symbol(const string& name, shared_ptr<Type> type, size_t tokenIndex) : 
+		Symbol(const string& name, Type type, size_t tokenIndex=0) : 
 			name{ name }, type{ type }, tokenIndex{ tokenIndex }
 		{}
 		
@@ -35,13 +35,15 @@ namespace bluefin {
 		// groups of shared pointers. They would use this ctor, so create custom deleter
 		// that doesn't delete this. 
 		// NOTE: Implementation Hack
+		/*
 		Symbol(const string& name, Type* t) : 
 			name{ name }, type{ t, [](Type*) {} }, tokenIndex{ 0 }
 		{}
+		*/
 
 	private:
 		const string name;
-		shared_ptr<Type> type; // a variableSymbol or other symbols may require this type for their ctors
+		Type type; // a variableSymbol or other symbols may require this type for their ctors
 		size_t tokenIndex;
 	};
 }

--- a/symbolTable/SymbolFactory.cpp
+++ b/symbolTable/SymbolFactory.cpp
@@ -25,7 +25,7 @@ shared_ptr<Symbol> SymbolFactory::createBuiltinTypeSymbol(Builtin builtin) {
 	}
 }
 
-unique_ptr<Symbol> SymbolFactory::createFunctionSymbol(const string& name, shared_ptr<Type> type, size_t tokenIndex) {
+unique_ptr<Symbol> SymbolFactory::createFunctionSymbol(const string& name, Type type, size_t tokenIndex) {
 	return unique_ptr<Symbol>(new FunctionSymbol(name, type, tokenIndex));
 }
 
@@ -33,6 +33,6 @@ unique_ptr<Symbol> SymbolFactory::createStructSymbol(const string& name, shared_
 	return unique_ptr<Symbol>(new StructSymbol(name, enclosingScope, superClass));
 }
 
-unique_ptr<Symbol> SymbolFactory::createVariableSymbol(const string& name, shared_ptr<Type> type, size_t tokenIndex) {
+unique_ptr<Symbol> SymbolFactory::createVariableSymbol(const string& name, Type type, size_t tokenIndex) {
 	return unique_ptr<Symbol>(new VariableSymbol(name, type, tokenIndex));
 }

--- a/symbolTable/SymbolFactory.h
+++ b/symbolTable/SymbolFactory.h
@@ -20,9 +20,9 @@ namespace bluefin {
 		};
 
 		virtual shared_ptr<Symbol> createBuiltinTypeSymbol(Builtin builtin);
-		virtual unique_ptr<Symbol> createFunctionSymbol(const string& name, shared_ptr<Type> type, size_t tokenIndex);
+		virtual unique_ptr<Symbol> createFunctionSymbol(const string& name, Type type, size_t tokenIndex);
 		virtual unique_ptr<Symbol> createStructSymbol(const string& name, shared_ptr<Scope> enclosingScope, shared_ptr<StructSymbol> superClass=nullptr);
-		virtual unique_ptr<Symbol> createVariableSymbol(const string& name, shared_ptr<Type> type, size_t tokenIndex);
+		virtual unique_ptr<Symbol> createVariableSymbol(const string& name, Type type, size_t tokenIndex);
 	};
 
 }

--- a/symbolTable/SymbolTable.cpp
+++ b/symbolTable/SymbolTable.cpp
@@ -43,6 +43,10 @@ namespace bluefin {
 
 	void SymbolTable::declare(shared_ptr<Symbol> symbol) {
 		currScope->declare(symbol);
+
+		if (shared_ptr<StructSymbol> structSym = dynamic_pointer_cast<StructSymbol>(symbol)) {
+			addUserDefinedType(structSym);
+		}
 	}
 
 
@@ -56,5 +60,21 @@ namespace bluefin {
 		} while (scope = scope->getEnclosingScope());
 
 		throw UnresolvedSymbolException(name);
+	}
+
+	shared_ptr<Symbol> SymbolTable::getSymbolMatchingType(Type type) {
+
+		if (typeSymbols.find(type) != typeSymbols.end())
+			return typeSymbols.at(type);
+
+		throw UnresolvedSymbolException(type.type2str());
+	}
+
+	void SymbolTable::addUserDefinedType(shared_ptr<StructSymbol> structSym) {
+		if (typeSymbols.count(structSym->getType())) {
+			throw ReclarationException(structSym->getType().type2str());
+		}
+
+		typeSymbols.emplace(structSym->getType(), structSym);
 	}
 }

--- a/symbolTable/SymbolTable.h
+++ b/symbolTable/SymbolTable.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
 #include "Scope.h"
 #include "../TestBluefin/utils.h"
 
@@ -9,6 +10,10 @@ namespace bluefin {
 	using std::shared_ptr;
 	using std::unique_ptr;;
 	using std::make_shared;
+	using std::unordered_map;
+
+	class StructSymbol;
+
 
 	class SymbolTable
 	{
@@ -22,7 +27,6 @@ namespace bluefin {
 		virtual void exitScope();
 
 		virtual void declare(shared_ptr<Symbol> symbol);
-
 
 		/*
 		Find the name in the curr scope, if not, find in its 
@@ -38,8 +42,13 @@ namespace bluefin {
 		*/
 		inline shared_ptr<Scope> getCurrScope() const { return currScope; }
 
+		virtual shared_ptr<Symbol> getSymbolMatchingType(Type type);
+
 	private:
+		void addUserDefinedType(shared_ptr<StructSymbol>);
+
 		shared_ptr<Scope> currScope; // shared_ptr b/c it can refer to the same scope as a StructSymbol's
+		unordered_map<Type, shared_ptr<Symbol>> typeSymbols;
 	};
 
 }

--- a/symbolTable/Type.h
+++ b/symbolTable/Type.h
@@ -5,31 +5,65 @@
 namespace bluefin {
 
 	using std::string;
+	using std::hash;
 
 	/*
-	Only BuiltinTypeSymbol and StructSymbol inherit from this.
-	They already have names, eg, "int", "float", "First", 
-	This "Type" is mostly used as a tag. However, it does 
-	contain a toString method, which returns the same as the Symbol's name,
-	in order to print the type. Used mostly for type checking testing
+	In the past, BuiltinTypeSymbol and StructSymbol inherited from this.
+	Now, no class should inherit this. It should be composed. 
+	Types are internally stored as strings, such as "int", "float", "First", 
+	Used mostly for type checking testing
 
-	There are 5 default types: int, float, string, bool void
+	There are 5 default types: int, float, string, bool, void
 	Any other types would be user defined (via structs)
 	*/
+
 	class Type
 	{
 	public:
 
-		virtual string type2str() const = 0; 
+		static Type INT() { return Type{ "int" }; }
+		static Type BOOL() { return Type{ "bool" }; }
+		static Type FLOAT() { return Type{ "float" }; }
+		static Type STRING() { return Type{ "string" }; }
 
-		inline bool operator==(const Type& rhs) {
-			return this->type2str() == rhs.type2str();
+		string type2str() const {
+			return name;
 		}
 
-		virtual ~Type() {}
+		bool isUserDefinedType() const {
+			bool isBuiltinType = (name == "int" || name == "bool" || name == "float" || name == "string" || name == "void");
+			return !isBuiltinType;
+		}
 
-	protected:
-		Type() {}
+		explicit Type(string name) : name{ name } {}
+		~Type() {}
+
+	private:
+		string name;
+
 	};
+
+
+	inline bool operator ==(const Type& lhs, const Type& rhs) {
+		return lhs.type2str() == rhs.type2str();
+	}
+
+	inline bool operator !=(const Type& lhs, const Type& rhs) {
+		return lhs.type2str() != rhs.type2str();
+	}
+
+	inline bool operator <(const Type& lhs, const Type& rhs) {
+		return lhs.type2str() < rhs.type2str();
+	}
 }
 
+namespace std {
+	using bluefin::Type;
+
+	template <>
+	struct std::hash<Type> {
+		size_t operator()(const Type& type) const {
+			return hash<string>()(type.type2str());
+		}
+	};
+};

--- a/symbolTable/TypeContext.h
+++ b/symbolTable/TypeContext.h
@@ -4,25 +4,25 @@
 #include "Type.h"
 
 namespace bluefin {
-	using std::shared_ptr;
 
 	class TypeContext {
 	public:
-		TypeContext(shared_ptr<Type> type) : evalType{ type }, promotionType{ type }
+		TypeContext(Type type) : evalType{ type }, promotionType{ type }
 		{}
 
-		inline shared_ptr<Type> getEvalType() const { return evalType; }
-		inline shared_ptr<Type> getPromotionType() const { return promotionType; }
+		inline Type getEvalType() const { return evalType; }
+		inline Type getPromotionType() const { return promotionType; }
 
-		inline void setPromotionType(shared_ptr<Type> type) { promotionType = type; }
+		inline void setPromotionType(Type type) { promotionType = type; }
 	
 	private:
-		shared_ptr<Type> evalType; // This is a sp b/c Symbol::getType() returns a sp. If there were no user-defined types (struct)
+		Type evalType; // If there were no user-defined types (struct)
 		// or if struct didn't inherit from Type, then can use enum instead. We do need the type2str to get the exact 
 		// user-defined type, and the struct as a subtype b/c it contains its own scope for members
 
-		shared_ptr<Type> promotionType; // since only builtin types can be promoted, so no need for actual type object
+		Type promotionType; // since only builtin types can be promoted (for now), so no need for actual type object
 		// TODO: some types can't be promoted by language rules (eg, bool), so we should
 		// separate promotable ones into a different kind of type context
+		// TODO 2: How to handle polymorphism withi promotionType? To think, if this is even possible
 	};
 }

--- a/symbolTable/VariableSymbol.h
+++ b/symbolTable/VariableSymbol.h
@@ -9,13 +9,12 @@ namespace bluefin {
 
 	using std::string;
 	using std::shared_ptr;
-	using std::move;
 
 	class VariableSymbol : public Symbol {
 
 	public:
-		VariableSymbol(const string& name, shared_ptr<Type> type, size_t tokenIndex) :
-			Symbol(name, move(type), tokenIndex) 
+		VariableSymbol(const string& name, Type type, size_t tokenIndex) :
+			Symbol(name, type, tokenIndex) 
 		{}
 	};
 }


### PR DESCRIPTION
Other changes:
- Added `Type::isUserDefinedType()` and specialized template so Type can be put in unordered_map
- To retrieve the StructSym corresponding to a Type, added `SymbolTable::getSymbolMatchingType(..)` and a map in SymbolTable that matches Type to StructSym
- Everywhere else, pass Type by value, not within a shared pointer