### PR TITLE
Refactor the way ParseTree* is passed b/t Declaration, Resolution, and DecorateTypesWithExpr by using SymbolTable rather than scope map

### DIFF
--- a/TestBluefin/symbolTable/InheritanceTests.cpp
+++ b/TestBluefin/symbolTable/InheritanceTests.cpp
@@ -35,7 +35,7 @@ namespace SymbolTableTests {
 		declarationListener.attachEventObserver(obs);
 		walker.walk(&declarationListener, tree);
 
-		Resolution resolutionListener(declarationListener.getScopes(), symTab);
+		Resolution resolutionListener(symTab);
 		resolutionListener.attachEventObserver(obs);
 		walker.walk(&resolutionListener, tree);
 

--- a/TestBluefin/symbolTable/PolymorphismTests.cpp
+++ b/TestBluefin/symbolTable/PolymorphismTests.cpp
@@ -33,7 +33,7 @@ namespace SymbolTableTests {
 		Declaration declarationListener(symTab, symFact);
 		walker.walk(&declarationListener, tree);
 
-		Resolution resolutionListener(declarationListener.getScopes(), symTab);
+		Resolution resolutionListener(symTab);
 		walker.walk(&resolutionListener, tree);
 
 		string expectedOutput = readFile(pathPrefix + expectedOutputFile);

--- a/TestBluefin/symbolTable/PopulateSymTabTests.cpp
+++ b/TestBluefin/symbolTable/PopulateSymTabTests.cpp
@@ -35,7 +35,7 @@ namespace SymbolTableTests {
 		declarationListener.attachEventObserver(obs);
 		walker.walk(&declarationListener, tree);
 
-		Resolution resolutionListener(declarationListener.getScopes(), symTab);
+		Resolution resolutionListener(symTab);
 		resolutionListener.attachEventObserver(obs);
 		walker.walk(&resolutionListener, tree);
 

--- a/TestBluefin/symbolTable/TypeTests.cpp
+++ b/TestBluefin/symbolTable/TypeTests.cpp
@@ -39,11 +39,10 @@ namespace SymbolTableTests {
 		Declaration declarationListener(symTab, symFact);
 		walker.walk(&declarationListener, tree);
 
-		Resolution resolutionListener(declarationListener.getScopes(), symTab);
+		Resolution resolutionListener(symTab);
 		walker.walk(&resolutionListener, tree);
 
-		map<ParseTree*, shared_ptr<Scope>> scopes = declarationListener.getScopes(); 
-		DecorateExprWithTypes decorateExprListener(scopes, symFact, symTab);
+		DecorateExprWithTypes decorateExprListener(symFact, symTab);
 		walker.walk(&decorateExprListener, tree);
 
 		string symbolTypesStr;

--- a/TestBluefin/symbolTable/scopeTests.cpp
+++ b/TestBluefin/symbolTable/scopeTests.cpp
@@ -226,9 +226,9 @@ namespace SymbolTableTests {
 		symtab.declare(symA);
 		symtab.declare(symB);
 
-		shared_ptr<Symbol> resA = symtab.resolve("a");
-		shared_ptr<Symbol> resA2 = symtab.resolve("a");
-		shared_ptr<Symbol> resB = symtab.resolve("b");
+		shared_ptr<Symbol> resA = symtab.resolve("a", symtab.getCurrScope());
+		shared_ptr<Symbol> resA2 = symtab.resolve("a", symtab.getCurrScope());
+		shared_ptr<Symbol> resB = symtab.resolve("b", symtab.getCurrScope());
 
 		ASSERT_EQ(resA, symA);
 		ASSERT_EQ(resA2, symA);
@@ -249,13 +249,13 @@ namespace SymbolTableTests {
 		shared_ptr<Symbol> symA2 = make_shared<VariableSymbol>("a", Type::INT(), 0);
 		symtab.declare(symA2);
 
-		shared_ptr<Symbol> resA2 = symtab.resolve("a");
-		shared_ptr<Symbol> resB = symtab.resolve("b");
+		shared_ptr<Symbol> resA2 = symtab.resolve("a", symtab.getCurrScope());
+		shared_ptr<Symbol> resB = symtab.resolve("b", symtab.getCurrScope());
 		ASSERT_EQ(resA2, symA2);
 		ASSERT_EQ(resB, symB);
 
 		symtab.exitScope();
-		shared_ptr<Symbol> resA = symtab.resolve("a");
+		shared_ptr<Symbol> resA = symtab.resolve("a", symtab.getCurrScope());
 		ASSERT_EQ(resA, symA);
 	}
 
@@ -270,7 +270,7 @@ namespace SymbolTableTests {
 		symtab.declare(symB);
 
 		symtab.enterScope("Second");
-		EXPECT_THROW(symtab.resolve("c"), UnresolvedSymbolException);
+		EXPECT_THROW(symtab.resolve("c", symtab.getCurrScope()), UnresolvedSymbolException);
 	}
 
 	TEST(SymbolTable, StructResolveMember) {
@@ -293,7 +293,7 @@ namespace SymbolTableTests {
 		symtab.exitScope();
 
 		// A a;
-		shared_ptr<Symbol> resolveA = symtab.resolve("A");
+		shared_ptr<Symbol> resolveA = symtab.resolve("A", symtab.getCurrScope());
 		ASSERT_EQ(resolveA, structA);
 		shared_ptr<Symbol> declarea = make_shared<VariableSymbol>("a", structA->getType(), 0);
 		symtab.declare(declarea);
@@ -319,7 +319,7 @@ namespace SymbolTableTests {
 		symtab.exitScope();
 
 		// A a;
-		shared_ptr<Symbol> resolveA = symtab.resolve("A");
+		shared_ptr<Symbol> resolveA = symtab.resolve("A", symtab.getCurrScope());
 		ASSERT_EQ(resolveA, structA);
 		shared_ptr<Symbol> declarea = make_shared<VariableSymbol>("a", structA->getType(), 0);
 		symtab.declare(declarea);

--- a/listeners/Declaration.cpp
+++ b/listeners/Declaration.cpp
@@ -21,7 +21,6 @@ void Declaration::enterVarDecl(bluefinParser::VarDeclContext* ctx) {
 	catch (RedeclarationException e) {
 		broadcastEvent(ErrorEvent::REDECLARED_EXISTING_SYMBOL, varName);
 	}
-	scopes.emplace(ctx, symbolTable.getCurrScope());
 }
 
 void Declaration::enterFuncDef(bluefinParser::FuncDefContext* ctx) {
@@ -38,7 +37,6 @@ void Declaration::enterFuncDef(bluefinParser::FuncDefContext* ctx) {
 		broadcastEvent(ErrorEvent::REDECLARED_EXISTING_SYMBOL, funcName);
 	}
 	currFunctionSym = dynamic_pointer_cast<FunctionSymbol>(funcSym);
-	scopes.emplace(ctx, symbolTable.getCurrScope());
 
 	symbolTable.enterScope("function " + ctx->ID()->getText());
 	broadcastEvent(ScopeEvent::ENTERING_SCOPE);
@@ -190,13 +188,11 @@ void Declaration::exitStructDef(bluefinParser::StructDefContext* ctx)
 }
 
 void Declaration::enterPrimaryId(bluefinParser::PrimaryIdContext* ctx) {
-	scopes.emplace(ctx, symbolTable.getCurrScope());
 	symbolTable.saveParseTreeWithCurrentScope(ctx);
 }
 
 void Declaration::enterFuncCall(bluefinParser::FuncCallContext* ctx)
 {
-	scopes.emplace(ctx, symbolTable.getCurrScope()); // will be used in later pass to resolve this ctx name again
 	symbolTable.saveParseTreeWithCurrentScope(ctx);
 }
 

--- a/listeners/Declaration.h
+++ b/listeners/Declaration.h
@@ -49,9 +49,6 @@ namespace bluefin {
 		void exitBlock(bluefinParser::BlockContext*) override;
 		void exitFuncDef(bluefinParser::FuncDefContext*) override;
 		void enterFuncCall(bluefinParser::FuncCallContext*) override;
-		//void exitMemberAccess(bluefinParser::MemberAccessContext*) override;
-
-		inline map<ParseTree*, shared_ptr<Scope>> getScopes() const { return scopes; }
 
 		inline ErrorCollector getErrorCollector() const { return errCollector; }
 		void attachEventObserver(shared_ptr<EventObserver>);
@@ -66,15 +63,6 @@ namespace bluefin {
 		void broadcastEvent(ScopeEvent);
 		void broadcastEvent(SuccessEvent, shared_ptr<Symbol>, shared_ptr<StructSymbol> structSym = nullptr);
 		void broadcastEvent(ErrorEvent, string, shared_ptr<StructSymbol> structSym=nullptr);
-
-		// Stores the scope associated with ParseTree contexts for future passes (resolution and type promotion
-		// NOTE: TODO: don't resolve here. to later resolve member access fields, we must resolve the ID within the expr, which can either be a 
-		// primaryId or another member access. This means that we must associate the member access' context with the 
-		// scope of the struct type. (eg, a.b.c, for a.b, we must associate that ctx with the type of b, to resolve c)
-		// This also means if the member is a primitive, we can't place it into the scope, suggesting not all member access will be placed within scope
-		// only those whose member are a struct type (scope).
-		// TODO: This applies to methods as well, but does it make sense to allow chained method calls? a.b().c()
-		map<ParseTree*, shared_ptr<Scope>> scopes;
 
 		// to share a functionSymbol with its associated params
 		shared_ptr<FunctionSymbol> currFunctionSym;

--- a/listeners/DecorateExprWithTypes.h
+++ b/listeners/DecorateExprWithTypes.h
@@ -33,8 +33,8 @@ namespace bluefin {
 	public:
 
 		// For testing, we'll pass in an adapter of a symbol table
-		DecorateExprWithTypes(map<ParseTree*, shared_ptr<Scope>> scopeOfPrimaryIds, SymbolFactory& factory, SymbolTable& symTab) :
-			scopeOfPrimaryIdsVarDeclAndFuncDefs{ scopeOfPrimaryIds }, symbolFactory{ factory }, symbolTable{ symTab }, currFuncDefCtx{ nullptr }
+		DecorateExprWithTypes(SymbolFactory& factory, SymbolTable& symTab) :
+			symbolFactory{ factory }, symbolTable{ symTab }, currFuncDefCtx{ nullptr }
 		{}
 
 		//===== listener methods for obtaining/evaluating expression types
@@ -70,12 +70,9 @@ namespace bluefin {
 	private:
 		SymbolFactory& symbolFactory;
 		SymbolTable& symbolTable;
-		map<ParseTree*, shared_ptr<Scope>> scopeOfPrimaryIdsVarDeclAndFuncDefs;
 
 		map<ParseTree*, TypeContext> typeContexts; // stores the type associated with expressions and functions. Enables type checking
 		bluefinParser::FuncDefContext* currFuncDefCtx;
-
-		shared_ptr<Symbol> resolve(const string name, shared_ptr<Scope> startScope);
 
 		// ==== How to update type
 		// 1. When we visit a primary, compute its type

--- a/listeners/Resolution.h
+++ b/listeners/Resolution.h
@@ -32,8 +32,6 @@ namespace bluefin {
 	class Resolution : public bluefinBaseListener
 	{
 	public:
-		// For testing, we'll pass in an adapter of a symbol table
-		// TODO: find some way to decouple testing of output from Resolution
 		Resolution(map<ParseTree*, shared_ptr<Scope>> scopes, SymbolTable& symTab) : 
 			scopes{ scopes },  symbolTable{symTab}
 		{}
@@ -51,7 +49,6 @@ namespace bluefin {
 
 	private:
 		map<ParseTree*, shared_ptr<Scope>> scopes;
-		pair<shared_ptr<Symbol>, shared_ptr<Scope>> resolve(const string name, shared_ptr<Scope> startScope);
 
 		SymbolTable& symbolTable;
 		/* 
@@ -79,8 +76,5 @@ namespace bluefin {
 
 		void broadcastEvent(SuccessEvent, shared_ptr<Symbol>, shared_ptr<StructSymbol> structSym = nullptr);
 		void broadcastEvent(ErrorEvent, string, shared_ptr<StructSymbol> structSym=nullptr);
-
-		pair<shared_ptr<Symbol>, shared_ptr<Scope>> resolveImpl(const string name, shared_ptr<Scope> startScope);	
-
 	};
 }

--- a/listeners/Resolution.h
+++ b/listeners/Resolution.h
@@ -32,8 +32,7 @@ namespace bluefin {
 	class Resolution : public bluefinBaseListener
 	{
 	public:
-		Resolution(map<ParseTree*, shared_ptr<Scope>> scopes, SymbolTable& symTab) : 
-			scopes{ scopes },  symbolTable{symTab}
+		Resolution(SymbolTable& symTab) : symbolTable{symTab}
 		{}
 
 		void enterVarDecl(bluefinParser::VarDeclContext * ctx) override;
@@ -48,8 +47,6 @@ namespace bluefin {
 		void detachEventObserver(shared_ptr<EventObserver>); // is this even called? If arg not found, no error would be thrown
 
 	private:
-		map<ParseTree*, shared_ptr<Scope>> scopes;
-
 		SymbolTable& symbolTable;
 		/* 
 		The purpose of this stack is to enable resolution of struct members. Since each 

--- a/symbolTable/SymbolTable.h
+++ b/symbolTable/SymbolTable.h
@@ -59,8 +59,13 @@ namespace bluefin {
 		shared_ptr<Scope> currScope; // shared_ptr b/c it can refer to the same scope as a StructSymbol's
 		unordered_map<Type, shared_ptr<Symbol>> typeSymbols;
 
+		/* Declaration stores the symbol and scope associated with ParseTree contexts, so that future passes
+		(Resolution and type promotion) can access the scope info. Note, to resolve struct member access
+		we must store the StructSymbol as a scope (eg, for a.b.c, we must store the StructSymbol for a.b 
+		inside the context to later resolve c)
+		*/
 		struct Context {
-			shared_ptr<Scope> scope;
+			shared_ptr<Scope> scope; // the scope that the Symbol is in
 			shared_ptr<Symbol> sym;
 		};
 		unordered_map<ParseTree*, Context> parseTreeContexts;


### PR DESCRIPTION
This commit changes the way we pass scope info between the passes. 

Previously, Declaration would declare symbols into the `SymbolTable` and sometimes resolve from it (eg, StructSym's superclass). However, the scopes would be put into a different data structure (map) that's passed to `Resolution` and `DecorateExprWithTypes`, which uses it rather than the symbol table.

This commit removes the other data structure. All the `ParseTree*` information is passed via the `SymbolTable`, and Resolution/DecorateExprWithTypes simply retrieve from SymbolTable.